### PR TITLE
add group chat functionality and update message read logic

### DIFF
--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -2,25 +2,26 @@ class ConversationsController < ApplicationController
  	before_action :authenticate_user
 	
 	def index
- 		@users = User.all.alphabetical
- 		@conversations = Conversation.involving(current_user)
+ 		@conversations = Conversation.all
  		@patients = User.where(role: "patient").alphabetical
- 		@care_managers = User.where(role: "care_manager").alphabetical
+ 		if current_user.role == "patient"
+ 			@patient_conversation = Conversation.for_patient(current_user)
+ 		end
  	end
 
 	def create
- 		if Conversation.between(params[:sender_id],params[:recipient_id]).present?
-    	@conversation = Conversation.between(params[:sender_id], params[:recipient_id]).first
+ 		if Conversation.for_patient(params[:patient_id]).present?
+    	@conversation = Conversation.for_patient(params[:patient_id]).first
  		else
   		@conversation = Conversation.create!(conversation_params)
  		end
- 		
+
  		redirect_to conversation_messages_path(@conversation)
 	end
 
 	private
  	
  	def conversation_params
-  	params.permit(:sender_id, :recipient_id)
+  	params.require(:conversation)
  	end
 end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -14,12 +14,29 @@ class MessagesController < ApplicationController
       @messages = @conversation.messages
     end
     if @messages.unread.count > 0
-      @messages.unread.each do |message|
-        if message.user_id != current_user.id
-          message.read = true
-          message.save
+      if current_user.role == "patient"
+        @messages.unread.each do |message|
+          if message.user_id != current_user.id
+            message.read = true
+            message.save
+          end
         end
-      end
+      else # care manager
+        @messages.unread.each do |message|
+          if message.user_id != current_user.id
+            if message.user.role == "patient"
+              message.read = true
+              message.save
+            end
+          end
+        end
+      end  
+      #@messages.unread.each do |message|
+      #  if message.user_id != current_user.id
+      #    message.read = true
+      #    message.save
+      #  end
+      #end
     end
     @message = @conversation.messages.new
   end
@@ -30,6 +47,7 @@ class MessagesController < ApplicationController
   
   def create
     @message = @conversation.messages.new(message_params)
+    @message.user = current_user
     if @message.save
       redirect_to conversation_messages_path(@conversation)
     end

--- a/app/controllers/user_conversations_controller.rb
+++ b/app/controllers/user_conversations_controller.rb
@@ -1,0 +1,14 @@
+class UserConversationsController < ApplicationController
+  before_action :authenticate_user
+  before_action :set_conversation
+
+  def create
+    @user_conversation = @conversation.user_conversations.where(user_id: current_user.id).first_or_create
+    redirect_to conversation_messages_path(@conversation)
+  end
+
+  private
+    def set_conversation
+      @conversation = Conversation.find(params[:conversation_id])
+    end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,6 +7,10 @@ class UsersController < ApplicationController
 	  @user = User.new(user_params)
 	  if @user.save
 	  	session[:user_id] = @user.id
+      if @user.role == "patient"
+        conversation = Conversation.create!
+        UserConversation.create(user_id: @user.id, conversation_id: conversation.id)
+      end
 	    redirect_to home_path, :notice => "Signed up!"
 	  else
 	    render "new"

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -1,14 +1,14 @@
 class Conversation < ActiveRecord::Base
-	belongs_to :sender, :foreign_key => :sender_id, class_name: 'User'
- 	belongs_to :recipient, :foreign_key => :recipient_id, class_name: 'User'
+ 	has_many :user_conversations
+ 	has_many :users, through: :user_conversations
 	has_many :messages, dependent: :destroy
-	validates_uniqueness_of :sender_id, :scope => :recipient_id
 	
-	scope :between, -> (sender_id,recipient_id) do
- 		where("(conversations.sender_id = ? AND conversations.recipient_id =?) OR (conversations.sender_id = ? AND conversations.recipient_id =?)", sender_id,recipient_id, recipient_id, sender_id)
+	#scope :between, -> (sender_id, recipient_id) do
+ 	#	where("(conversations.sender_id = ? AND conversations.recipient_id =?) OR (conversations.sender_id = ? AND conversations.recipient_id =?)", sender_id,recipient_id, recipient_id, sender_id)
+ 	#end
+
+ 	def self.for_patient(patient)
+ 		UserConversation.where(user_id: patient.id).map{ |uc| uc.conversation }.first
  	end
 
- 	scope :involving, -> (user) do
-    where("conversations.sender_id =? OR conversations.recipient_id =?",user.id,user.id)
-  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,10 @@ class User < ActiveRecord::Base
 	attr_accessor :password
 	before_save :encrypt_password
 
+	has_many :user_conversations
+	has_many :chatrooms, through: :user_conversations
+	has_many :messages
+
 	validates_confirmation_of :password, :on => :create, :message => "Passwords do not match"
 	validates_presence_of :password, :on => :create, :message => "can't be blank"
 	validates_presence_of :email, :on => :create, :message => "can't be blank"

--- a/app/models/user_conversation.rb
+++ b/app/models/user_conversation.rb
@@ -1,0 +1,4 @@
+class UserConversation < ActiveRecord::Base
+	belongs_to :conversation
+	belongs_to :user
+end

--- a/app/views/conversations/index.html.erb
+++ b/app/views/conversations/index.html.erb
@@ -4,22 +4,17 @@
 	<h1>Your Messages</h1>
 <% end %>
 
-<h2>Inbox</h2>
-<% if @conversations.empty? %>
-	No messages
-<% else %>
-	<% @conversations.each do |conversation| %>
-		<% if conversation.sender_id == current_user.id %>
-			<% recipient = User.find(conversation.recipient_id) %>
-		<% else %>
-			<% recipient = User.find(conversation.sender_id) %>
-		<% end %>
+<% if current_user.role == "patient" %>
+	<h2>Inbox</h2>
+	<% if @patient_conversation.present? %>
 		<div class="panel panel-default">
 			<div class="panel-body">
-				<%= link_to recipient.full_name, conversation_messages_path(conversation)%>
-				<% if conversation.messages.last.user_id != current_user.id %>
-					<% if conversation.messages.unread.count > 0 %>
-						<strong>(<%= conversation.messages.unread.count %> unread)</strong>
+				<%= link_to "Your Care Conversation", conversation_messages_path(@patient_conversation)%>
+				<% if @patient_conversation.messages.present? %>
+					<% if @patient_conversation.messages.last.user_id != current_user.id %>
+						<% if @patient_conversation.messages.unread.count > 0 %>
+							<strong>(<%= @patient_conversation.messages.unread.count %> unread)</strong>
+						<% end %>
 					<% end %>
 				<% end %>
 			</div>
@@ -29,13 +24,21 @@
 
 <% if current_user.role == "care_manager" %>
 	<h2>All Patients</h2>
-	<% @patients.each do |user| %>
-		<% if user.id != current_user.id %>
-			<div class="panel panel-default">
-				<div class="panel-body">
-					<%= link_to user.full_name, conversations_path(sender_id: current_user.id, recipient_id: user.id), method: 'post' %>
-				</div>
+	<% @patients.each do |patient| %>
+		<% conversation = Conversation.for_patient(patient) %>
+		<div class="panel panel-default">
+			<div class="panel-body">
+				<%= link_to patient.full_name, conversation_messages_path(conversation) %>
+				<% if conversation.messages.present? %>
+					<% if conversation.messages.last.user_id != current_user.id %>
+						<% if conversation.messages.last.user.role == "patient" %>
+							<% if conversation.messages.unread.count > 0 %>
+								<strong>(<%= conversation.messages.unread.count %> unread)</strong>
+							<% end %>
+						<% end %>
+					<% end %>
+				<% end %>
 			</div>
-		<% end %>
+		</div>
 	<% end %>
 <% end %>

--- a/app/views/messages/index.html.erb
+++ b/app/views/messages/index.html.erb
@@ -15,9 +15,9 @@
   <% end %>
 <% end %>
 
-<%= form_for [@conversation, @message], html: {class: "ui reply form"} do |f| %>
+<%= form_for [@conversation, @message] do |f| %>
   <div class="input-group">
-    <%= f.text_area :body, class: "form-control", placeholder: "Type a message..." %>
+    <%= f.text_area :body, class: "form-control", placeholder: "Type a message...", autofocus: true %>
     <%= f.text_field :user_id, value: current_user.id, type: "hidden" %>
     <span class="input-group-btn">
       <%= f.submit "Send", class: "btn btn-primary btn-lg send-button" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   resources :sessions
   resources :conversations do
     resources :messages
+    resource :user_conversations
   end
 
   # The priority is based upon order of creation: first created -> highest priority.

--- a/db/migrate/20170217020841_create_conversations.rb
+++ b/db/migrate/20170217020841_create_conversations.rb
@@ -1,8 +1,6 @@
 class CreateConversations < ActiveRecord::Migration
   def change
     create_table :conversations do |t|
-    	t.integer :sender_id
-   		t.integer :recipient_id
 
    		t.timestamps
     end

--- a/db/migrate/20170220044659_create_user_conversations.rb
+++ b/db/migrate/20170220044659_create_user_conversations.rb
@@ -1,0 +1,10 @@
+class CreateUserConversations < ActiveRecord::Migration
+  def change
+    create_table :user_conversations do |t|
+      t.integer :user_id
+      t.integer :conversation_id
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,11 +11,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170217021715) do
+ActiveRecord::Schema.define(version: 20170220044659) do
 
   create_table "conversations", force: :cascade do |t|
-    t.integer  "sender_id"
-    t.integer  "recipient_id"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -31,6 +29,13 @@ ActiveRecord::Schema.define(version: 20170217021715) do
 
   add_index "messages", ["conversation_id"], name: "index_messages_on_conversation_id"
   add_index "messages", ["user_id"], name: "index_messages_on_user_id"
+
+  create_table "user_conversations", force: :cascade do |t|
+    t.integer  "user_id"
+    t.integer  "conversation_id"
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
+  end
 
   create_table "users", force: :cascade do |t|
     t.string   "role"

--- a/test/fixtures/user_conversations.yml
+++ b/test/fixtures/user_conversations.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user_id: 1
+  conversation_id: 1
+
+two:
+  user_id: 1
+  conversation_id: 1

--- a/test/models/conversation_test.rb
+++ b/test/models/conversation_test.rb
@@ -6,11 +6,8 @@ class ConversationTest < ActiveSupport::TestCase
   # end
 
   # test relationships
-  should belong_to(:sender)
-  should belong_to(:recipient)
+  should have_many(:user_conversations)
+  should have_many(:users).through(:user_conversations)
   should have_many(:messages)
-
-  # test validations
-  should validate_uniqueness_of(:sender_id)
 
 end

--- a/test/models/user_conversation_test.rb
+++ b/test/models/user_conversation_test.rb
@@ -1,0 +1,10 @@
+require 'test_helper'
+
+class UserConversationTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+
+  should belong_to(:conversation)
+  should belong_to(:user)
+end


### PR DESCRIPTION
Patients can now message multiple care managers in one conversation. 

Messages are marked as read if:
- written by a patient and seen by any care manager
- written by a care manager and seen by the patient